### PR TITLE
Change Encoding parameter sizes

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -28,7 +28,7 @@ pub enum Encoding<'a> {
     Class,
     Sel,
     Unknown,
-    BitField(u32),
+    BitField(u8),
     Pointer(&'a Encoding<'a>),
     Array(usize, &'a Encoding<'a>),
     Struct(&'a str, &'a [Encoding<'a>]),

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -30,7 +30,7 @@ pub enum Encoding<'a> {
     Unknown,
     BitField(u32),
     Pointer(&'a Encoding<'a>),
-    Array(u32, &'a Encoding<'a>),
+    Array(usize, &'a Encoding<'a>),
     Struct(&'a str, &'a [Encoding<'a>]),
     Union(&'a str, &'a [Encoding<'a>]),
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -75,7 +75,7 @@ fn rm_enc_prefix<'a>(s: &'a str, enc: &Encoding) -> Option<&'a str> {
     rm_prefix(s, code)
 }
 
-fn chomp_int(s: &str) -> Option<(u32, &str)> {
+fn chomp_int(s: &str) -> Option<(usize, &str)> {
     // Chomp until we hit a non-digit
     let (num, t) = match s.find(|c: char| !c.is_digit(10)) {
         Some(i) => s.split_at(i),
@@ -84,7 +84,7 @@ fn chomp_int(s: &str) -> Option<(u32, &str)> {
     num.parse().map(|n| (n, t)).ok()
 }
 
-fn rm_int_prefix(s: &str, other: u32) -> Option<&str> {
+fn rm_int_prefix(s: &str, other: usize) -> Option<&str> {
     chomp_int(s)
         .and_then(|(n, t)| if other == n { Some(t) } else { None })
 }


### PR DESCRIPTION
- Decrease `Encoding::BitField` size from `u32` to `u8`
    - A bitfield can only be created from integral types, whose maximum size is 64 (which can easily fit inside a `u8`)
- Increase `Encoding::Array` length from `u32` to `usize`
    - `@encode` can output an array size up to 2^61 - 1 elements:
    ```objective-c
    NSLog(@"Encoding: %s", @encode(char [((unsigned long long)(2) << 60) - 1]));
    ```

These are **breaking changes**, so we'd have to bump the major version number.

Please correct me on these if I'm wrong!