### PR TITLE
Use `str::strip_prefix` instead of custom `rm_prefix` function

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2,7 +2,7 @@
 
 use crate::Encoding;
 
-const QUALIFIERS: &'static [char] = &[
+const QUALIFIERS: &[char] = &[
     'r', // const
     'n', // in
     'N', // inout
@@ -36,43 +36,43 @@ fn rm_enc_prefix<'a>(s: &'a str, enc: &Encoding) -> Option<&'a str> {
         Sel       => ":",
         Unknown   => "?",
         BitField(b) => {
-            let s = rm_prefix(s, "b")?;
+            let s = s.strip_prefix("b")?;
             return rm_int_prefix(s, b);
         }
         Pointer(t) => {
-            let s = rm_prefix(s, "^")?;
+            let s = s.strip_prefix("^")?;
             return rm_enc_prefix(s, t);
         }
         Array(len, item) => {
             let mut s = s;
-            s = rm_prefix(s, "[")?;
+            s = s.strip_prefix("[")?;
             s = rm_int_prefix(s, len)?;
             s = rm_enc_prefix(s, item)?;
-            return rm_prefix(s, "]");
+            return s.strip_prefix("]");
         }
         Struct(name, fields) => {
             let mut s = s;
-            s = rm_prefix(s, "{")?;
-            s = rm_prefix(s, name)?;
-            s = rm_prefix(s, "=")?;
+            s = s.strip_prefix("{")?;
+            s = s.strip_prefix(name)?;
+            s = s.strip_prefix("=")?;
             for field in fields {
                 s = rm_enc_prefix(s, field)?;
             }
-            return rm_prefix(s, "}");
+            return s.strip_prefix("}");
         }
         Union(name, members) => {
             let mut s = s;
-            s = rm_prefix(s, "(")?;
-            s = rm_prefix(s, name)?;
-            s = rm_prefix(s, "=")?;
+            s = s.strip_prefix("(")?;
+            s = s.strip_prefix(name)?;
+            s = s.strip_prefix("=")?;
             for member in members {
                 s = rm_enc_prefix(s, member)?;
             }
-            return rm_prefix(s, ")");
+            return s.strip_prefix(")");
         }
     };
 
-    rm_prefix(s, code)
+    s.strip_prefix(code)
 }
 
 fn chomp_int(s: &str) -> Option<(u32, &str)> {
@@ -87,14 +87,6 @@ fn chomp_int(s: &str) -> Option<(u32, &str)> {
 fn rm_int_prefix(s: &str, other: u32) -> Option<&str> {
     chomp_int(s)
         .and_then(|(n, t)| if other == n { Some(t) } else { None })
-}
-
-fn rm_prefix<'a>(s: &'a str, other: &str) -> Option<&'a str> {
-    if s.starts_with(other) {
-        Some(&s[other.len()..])
-    } else {
-        None
-    }
 }
 
 pub fn eq_enc(s: &str, enc: &Encoding) -> bool {


### PR DESCRIPTION
See [the docs](https://doc.rust-lang.org/stable/std/primitive.str.html#method.strip_prefix).

Stabilized in Rust 1.45.0 - which means you might not want to merge this yet, since 32-bit support of `objc` is currently tested on `1.41.0`, since https://github.com/SSheldon/rust-objc/commit/c8696b0cd1932fdf1b5b22c03af86f32a934f42f.

This (together with removing `'static` from `QUALIFIERS`) appeases `clippy`.